### PR TITLE
Use proper header size in parseCommands

### DIFF
--- a/lib/macho/parser.js
+++ b/lib/macho/parser.js
@@ -96,6 +96,7 @@ Parser.prototype.parseHead = function parseHead(buf) {
     flags: flagMap,
 
     cmds: null,
+    hsize: bits === 32 ? 28 : 32,
     body: bits === 32 ? buf.slice(28) : buf.slice(32)
   };
 };
@@ -113,7 +114,7 @@ Parser.prototype.parseCommands = function parseCommands(hdr, buf, file) {
     var type = constants.cmdType[this.readUInt32(buf, offset)];
     var size = this.readUInt32(buf, offset + 4) - 8;
 
-    var fileoff = offset + 32;
+    var fileoff = offset + hdr.hsize;
     offset += 8;
     if (offset + size > buf.length)
       throw new Error('Command body OOB');


### PR DESCRIPTION
- exposed the hsize field in header
- fileoff is now correct also on 32 bit slices
